### PR TITLE
Handle unmount

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "author": "",
   "devDependencies": {
     "@eslint/js": "^9.25.1",
+    "@types/node": "^22.15.19",
     "@vitest/coverage-c8": "^0.33.0",
     "@vitest/coverage-v8": "^3.1.2",
     "eslint": "^9.25.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,15 @@ importers:
       '@eslint/js':
         specifier: ^9.25.1
         version: 9.25.1
+      '@types/node':
+        specifier: ^22.15.19
+        version: 22.15.19
       '@vitest/coverage-c8':
         specifier: ^0.33.0
-        version: 0.33.0(vitest@3.1.2(happy-dom@17.4.4))
+        version: 0.33.0(vitest@3.1.2(@types/node@22.15.19)(happy-dom@17.4.4))
       '@vitest/coverage-v8':
         specifier: ^3.1.2
-        version: 3.1.2(vitest@3.1.2(happy-dom@17.4.4))
+        version: 3.1.2(vitest@3.1.2(@types/node@22.15.19)(happy-dom@17.4.4))
       eslint:
         specifier: ^9.25.1
         version: 9.25.1
@@ -37,7 +40,7 @@ importers:
         version: 8.31.0(eslint@9.25.1)(typescript@5.8.3)
       vitest:
         specifier: ^3.1.2
-        version: 3.1.2(happy-dom@17.4.4)
+        version: 3.1.2(@types/node@22.15.19)(happy-dom@17.4.4)
 
 packages:
 
@@ -427,6 +430,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@22.15.19':
+    resolution: {integrity: sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==}
 
   '@typescript-eslint/eslint-plugin@8.31.0':
     resolution: {integrity: sha512-evaQJZ/J/S4wisevDvC1KFZkPzRetH8kYZbkgcTRyql3mcKsf+ZFDV1BVWUGTCAW5pQHoqn5gK5b8kn7ou9aFQ==}
@@ -1264,6 +1270,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -1664,6 +1673,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node@22.15.19':
+    dependencies:
+      undici-types: 6.21.0
+
   '@typescript-eslint/eslint-plugin@8.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.8.3))(eslint@9.25.1)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -1741,16 +1754,16 @@ snapshots:
       '@typescript-eslint/types': 8.31.0
       eslint-visitor-keys: 4.2.0
 
-  '@vitest/coverage-c8@0.33.0(vitest@3.1.2(happy-dom@17.4.4))':
+  '@vitest/coverage-c8@0.33.0(vitest@3.1.2(@types/node@22.15.19)(happy-dom@17.4.4))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       c8: 7.14.0
       magic-string: 0.30.17
       picocolors: 1.1.1
       std-env: 3.9.0
-      vitest: 3.1.2(happy-dom@17.4.4)
+      vitest: 3.1.2(@types/node@22.15.19)(happy-dom@17.4.4)
 
-  '@vitest/coverage-v8@3.1.2(vitest@3.1.2(happy-dom@17.4.4))':
+  '@vitest/coverage-v8@3.1.2(vitest@3.1.2(@types/node@22.15.19)(happy-dom@17.4.4))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -1764,7 +1777,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.2(happy-dom@17.4.4)
+      vitest: 3.1.2(@types/node@22.15.19)(happy-dom@17.4.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -1775,13 +1788,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.2(vite@6.3.3)':
+  '@vitest/mocker@3.1.2(vite@6.3.3(@types/node@22.15.19))':
     dependencies:
       '@vitest/spy': 3.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.3
+      vite: 6.3.3(@types/node@22.15.19)
 
   '@vitest/pretty-format@3.1.2':
     dependencies:
@@ -2547,6 +2560,8 @@ snapshots:
 
   typescript@5.8.3: {}
 
+  undici-types@6.21.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -2557,13 +2572,13 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite-node@3.1.2:
+  vite-node@3.1.2(@types/node@22.15.19):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.3
+      vite: 6.3.3(@types/node@22.15.19)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2578,7 +2593,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.3:
+  vite@6.3.3(@types/node@22.15.19):
     dependencies:
       esbuild: 0.25.3
       fdir: 6.4.4(picomatch@4.0.2)
@@ -2587,12 +2602,13 @@ snapshots:
       rollup: 4.40.0
       tinyglobby: 0.2.13
     optionalDependencies:
+      '@types/node': 22.15.19
       fsevents: 2.3.3
 
-  vitest@3.1.2(happy-dom@17.4.4):
+  vitest@3.1.2(@types/node@22.15.19)(happy-dom@17.4.4):
     dependencies:
       '@vitest/expect': 3.1.2
-      '@vitest/mocker': 3.1.2(vite@6.3.3)
+      '@vitest/mocker': 3.1.2(vite@6.3.3(@types/node@22.15.19))
       '@vitest/pretty-format': 3.1.2
       '@vitest/runner': 3.1.2
       '@vitest/snapshot': 3.1.2
@@ -2609,10 +2625,11 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.3
-      vite-node: 3.1.2
+      vite: 6.3.3(@types/node@22.15.19)
+      vite-node: 3.1.2(@types/node@22.15.19)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 22.15.19
       happy-dom: 17.4.4
     transitivePeerDependencies:
       - jiti

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -1,0 +1,1 @@
+export const isTestMode = process.env["NODE_ENV"] === "test";

--- a/src/tests/el.test.ts
+++ b/src/tests/el.test.ts
@@ -1,6 +1,6 @@
-import { el } from "../el";
+import { el, unmountRegistry } from "../el";
 
-describe("el function", () => {
+describe("el", () => {
   beforeEach(() => {
     // Setup: create a container for our tests
     const container = document.createElement("div");
@@ -16,86 +16,109 @@ describe("el function", () => {
     }
   });
 
-  it("creates an HTML element with the specified tag", () => {
-    const button = el("button").done();
-    expect(button.tagName).toBe("BUTTON");
-  });
-
-  it("sets text content", () => {
-    const text = "Click me";
-    const button = el("button").text(text).done();
-    expect(button.textContent).toBe(text);
-  });
-
-  it("supports dynamic text content with functions", () => {
-    let count = 0;
-    const button = el("button")
-      .text(() => `Count: ${count}`)
-      .done();
-
-    expect(button.textContent).toBe("Count: 0");
-    count = 1;
-    // TODO: In the future this would be a reactive value anyways
-    // Need to trigger an update here in a real app
-  });
-
-  it("adds CSS classes", () => {
-    const button = el("button").class("btn btn-primary").done();
-
-    expect(button.className).toBe("btn btn-primary");
-  });
-
-  it("sets attributes", () => {
-    const link = el("a")
-      .attr({ href: "https://example.com", target: "_blank" })
-      .done();
-
-    expect(link.getAttribute("href")).toBe("https://example.com");
-    expect(link.getAttribute("target")).toBe("_blank");
-  });
-
-  it("attaches event listeners", () => {
-    const handleClick = vi.fn();
-    const button = el("button").on("click", handleClick).done();
-
-    button.click();
-    expect(handleClick).toHaveBeenCalledTimes(1);
-  });
-
-  it("adds child elements", () => {
-    const parent = el("div")
-      .add(el("span").text("Child 1").done(), el("span").text("Child 2").done())
-      .done();
-
-    expect(parent.children.length).toBe(2);
-    expect(parent.children[0].textContent).toBe("Child 1");
-    expect(parent.children[1].textContent).toBe("Child 2");
-  });
-
-  it("sets styles", () => {
-    vi.stubGlobal("requestAnimationFrame", (fn: FrameRequestCallback) => {
-      fn(0);
-      return 0;
+  describe("Basic functionality", () => {
+    it("creates an HTML element with the specified tag", () => {
+      const button = el("button").done();
+      expect(button.tagName).toBe("BUTTON");
     });
 
-    const div = el("div").style({ color: "red", fontSize: "16px" }).done();
+    it("sets text content", () => {
+      const text = "Click me";
+      const button = el("button").text(text).done();
+      expect(button.textContent).toBe(text);
+    });
 
-    expect(div.style.color).toBe("red");
-    expect(div.style.fontSize).toBe("16px");
+    it("supports dynamic text content with functions", () => {
+      let count = 0;
+      const button = el("button")
+        .text(() => `Count: ${count}`)
+        .done();
 
-    vi.unstubAllGlobals();
+      expect(button.textContent).toBe("Count: 0");
+      count = 1;
+      // TODO: In the future this would be a reactive value anyways
+      // Need to trigger an update here in a real app
+    });
+
+    it("adds CSS classes", () => {
+      const button = el("button").class("btn btn-primary").done();
+
+      expect(button.className).toBe("btn btn-primary");
+    });
+
+    it("sets attributes", () => {
+      const link = el("a")
+        .attr({ href: "https://example.com", target: "_blank" })
+        .done();
+
+      expect(link.getAttribute("href")).toBe("https://example.com");
+      expect(link.getAttribute("target")).toBe("_blank");
+    });
+
+    it("attaches event listeners", () => {
+      const handleClick = vi.fn();
+      const button = el("button").on("click", handleClick).done();
+
+      button.click();
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("adds child elements", () => {
+      const parent = el("div")
+        .add(
+          el("span").text("Child 1").done(),
+          el("span").text("Child 2").done()
+        )
+        .done();
+
+      expect(parent.children.length).toBe(2);
+      expect(parent.children[0].textContent).toBe("Child 1");
+      expect(parent.children[1].textContent).toBe("Child 2");
+    });
+
+    it("sets styles", () => {
+      vi.stubGlobal("requestAnimationFrame", (fn: FrameRequestCallback) => {
+        fn(0);
+        return 0;
+      });
+
+      const div = el("div").style({ color: "red", fontSize: "16px" }).done();
+
+      expect(div.style.color).toBe("red");
+      expect(div.style.fontSize).toBe("16px");
+
+      vi.unstubAllGlobals();
+    });
+
+    it("chains methods correctly", () => {
+      const button = el("button")
+        .class("btn")
+        .text("Click me")
+        .attr({ type: "button" })
+        .style({ color: "blue" })
+        .done();
+
+      expect(button.className).toBe("btn");
+      expect(button.textContent).toBe("Click me");
+      expect(button.getAttribute("type")).toBe("button");
+    });
   });
 
-  it("chains methods correctly", () => {
-    const button = el("button")
-      .class("btn")
-      .text("Click me")
-      .attr({ type: "button" })
-      .style({ color: "blue" })
-      .done();
+  describe("onUnmount", () => {
+    it("executes callback when element is removed from DOM", () => {
+      const callback = vi.fn();
+      const element = el("span")
+        .text("Test element")
+        .onUnmount(callback)
+        .done();
 
-    expect(button.className).toBe("btn");
-    expect(button.textContent).toBe("Click me");
-    expect(button.getAttribute("type")).toBe("button");
+      expect(unmountRegistry.has(element)).toBe(true);
+      expect(callback).not.toHaveBeenCalled();
+
+      const callbacks = unmountRegistry.get(element) || [];
+      callbacks.forEach((cb) => cb());
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -180,7 +180,7 @@ export function debounce<Args extends Array<unknown>, Return>(
   cancel: () => void;
   flush: () => Return | undefined;
 } {
-  let timeoutId: number | undefined;
+  let timeoutId: NodeJS.Timeout | undefined;
   let lastArgs: Args | undefined;
   let result: Return | undefined;
 
@@ -227,7 +227,7 @@ export function throttle<Args extends Array<unknown>, Return>(
   cancel: () => void;
 } {
   let lastCallTime: number | undefined;
-  let timeoutId: number | undefined;
+  let timeoutId: NodeJS.Timeout | undefined;
   let lastArgs: Args | undefined;
   let result: Return | undefined;
 


### PR DESCRIPTION
the reason we went with this mutation observers approach is to keep it performant but also simple

its why we use a weakmap too, to ensure its gabaage colelctied when no longer needed

initially idea was just doing subtree true from the root

but this has performance impliciation

now we only watch children wit childList directly from parents